### PR TITLE
fix(boot): glossary merge respects GC tombstones

### DIFF
--- a/unmassk-toolkit/hooks/session-start-boot.py
+++ b/unmassk-toolkit/hooks/session-start-boot.py
@@ -448,6 +448,7 @@ def extract_memory() -> dict:
         "decisions": decisions,
         "memos": memos,
         "remembers": remembers,
+        "tombstones": tombstones,
     }
 
 
@@ -977,15 +978,17 @@ def main() -> None:
     lines.append("")
 
     # ── REMEMBER ────────────────────────────────────────────────────
-    # Merge recent + glossary remembers
+    # Merge recent + glossary remembers (skip tombstoned entries)
     glossary = extract_glossary_cached()
+    tombstones = memory.get("tombstones", set())
 
     all_remembers: list[tuple[str, str]] = list(memory.get("remembers", []))
     recent_remember_texts = {normalize(t) for _, t in all_remembers}
     for scope, text in glossary.get("remembers", []):
-        if normalize(text) not in recent_remember_texts:
+        norm = normalize(text)
+        if norm not in recent_remember_texts and norm not in tombstones:
             all_remembers.append((scope, text))
-            recent_remember_texts.add(normalize(text))
+            recent_remember_texts.add(norm)
 
     if all_remembers:
         lines.append("REMEMBER:")
@@ -1021,7 +1024,7 @@ def main() -> None:
     all_memos: list[tuple[str, str]] = list(memory.get("memos", []))
     recent_memo_scopes = {s for s, _ in all_memos}
     for scope, text in glossary.get("memos", []):
-        if scope not in recent_memo_scopes:
+        if scope not in recent_memo_scopes and normalize(text) not in tombstones:
             all_memos.append((scope, text))
             recent_memo_scopes.add(scope)
 


### PR DESCRIPTION
## Summary
- **Bug fix**: `extract_glossary()` did not filter entries marked with `Resolved-Remember` or `Resolved-Memo` tombstones, causing GC-cleared remembers/memos to be re-added during the glossary merge step of boot
- **Fix**: `extract_memory()` now returns collected tombstones, and the REMEMBER/MEMOS merge sections check glossary entries against them before re-adding
- **GC executed**: consolidated 11 remember(claude) entries down to 5 via condensing duplicates and tombstoning covered entries

## Test plan
- [x] Ran `session-start-boot.py` before fix — tombstoned remembers still visible (15 entries)
- [x] Ran `session-start-boot.py` after fix — only 7 remembers shown (5 claude + 2 user), no GC warning
- [ ] Verify boot works correctly on a fresh session in another project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where deleted or marked items were incorrectly appearing in active views by implementing proper exclusion tracking and filtering throughout the memory aggregation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->